### PR TITLE
Clean up; Convert Flex to Grid

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-slate

--- a/form.html
+++ b/form.html
@@ -14,10 +14,10 @@
 
 <body>
   <div class="nav">
-    <a href="/index.html"><img src="images/logo.png" alt="Logo Banner" /></a>
+    <a href="index.html"><img src="images/logo.png" alt="Logo Banner" /></a>
     <p>
-      <button> <a href="/index.html">home &#127968;</a></button>
-      <button> <a href="/form.html">share a donation link! &#127760;</a> </button>
+      <button> <a href="index.html">home &#127968;</a></button>
+      <button> <a href="form.html">share a donation link! &#127760;</a> </button>
     </p>
     <!-- Javascript Form to submit funds -->
   </div>

--- a/index.html
+++ b/index.html
@@ -14,18 +14,18 @@
 
 <body>
   <div class="nav">
-    <a href="/index.html"><img src="images/logo.png" alt="Logo Banner" /></a>
+    <a href="index.html"><img src="images/logo.png" alt="Logo Banner" /></a>
     <p>
-      <button> <a href="/index.html">home &#127968;</a></button>
-      <button> <a href="/form.html">share a donation link! &#127760;</a> </button>
+      <button> <a href="index.html">home &#127968;</a></button>
+      <button> <a href="form.html">share a donation link! &#127760;</a> </button>
     </p>
     <!-- Javascript Form to submit funds -->
   </div>
 
-  <div class="flex">
+  <div class="grid">
 
     <div class="box global" id="box">
-      <h1> global </h1>
+      <h1> global</h1>
       <p><a href="https://bit.ly/donateCHFcovid19" target="_blank">Children's Hunger Fund</a></p>
       <p><a href="https://uni.cf/2V8fODA" target="_blank">Unicef</a></p>
       <p><a href="https://bit.ly/donateUNcovid19" target="_blank">United Nations</a></p>

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -204,9 +204,9 @@ footer {
 
 /* mobile styling */
 
-@media (max-width: 1440px) {
+@media (max-width: 1600px) {
   .grid {
-    max-width: 1140px;
+    max-width: 1120px;
     grid-template-columns: repeat(2, 1fr);
     grid-template-areas:
     "global asia"
@@ -217,7 +217,7 @@ footer {
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width: 1200px) {
   .grid {
     max-width: 720px;
     grid-template-columns: 1fr;

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -68,19 +68,23 @@ button:hover {
 
 /* general box area styling */
 
-.flex {
-  display: flex;
-  flex-wrap: wrap;
-  margin: 0% 10%;
+.grid {
+  display: grid;
+  margin: auto;
+  max-width: 1520px;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: repeat(3, 1fr);
+  grid-template-areas:
+  "global asia europe"
+  "namerica camerica samerica"
+  "africa oceania meast";
 }
 
 .box {
-  flex-grow: 1;
   font-size: 24px;
   height: 280px;
-  width: 300px;
-  margin: 10px 10px 60px 10px;
   padding: 30px;
+  margin: 15px;
   background-color: white;
   border-radius: 20px;
   transition: 0.5s;
@@ -102,6 +106,7 @@ button:hover {
 .africa {
   color: #d7986b;
   background-color: #ffcfac;
+  grid-area: africa;
 }
 
 .africa:hover {
@@ -111,6 +116,7 @@ button:hover {
 .asia {
   color: #deba04;
   background-color: #f8e16b;
+  grid-area: asia;
 }
 
 .asia:hover {
@@ -120,6 +126,7 @@ button:hover {
 .centralamerica {
   color: #E78B36;
   background-color: #FFBB7C;
+  grid-area: camerica;
 }
 
 .centralamerica:hover {
@@ -129,6 +136,7 @@ button:hover {
 .europe {
   color: #69b42f;
   background-color: #bbe19e;
+  grid-area: europe;
 }
 
 .europe:hover {
@@ -138,6 +146,7 @@ button:hover {
 .global {
   color: #B1BF05;
   background-color: #EAF473;
+  grid-area: global;
 }
 
 .global:hover {
@@ -147,6 +156,7 @@ button:hover {
 .middleeast {
   color: #9843AC;
   background-color: #C592D1;
+  grid-area: meast;
 }
 
 .middleeast:hover {
@@ -156,6 +166,7 @@ button:hover {
 .northamerica {
   color: #cc585e;
   background-color: #f4a0a5;
+  grid-area: namerica;
 }
 
 .northamerica:hover {
@@ -165,6 +176,7 @@ button:hover {
 .oceania {
   color: #5271c1;
   background-color: #9eb1e1;
+  grid-area: oceania;
 }
 
 .oceania:hover {
@@ -174,6 +186,7 @@ button:hover {
 .southamerica {
   color: #4598b3;
   background-color: #9ed1e1;
+  grid-area: samerica;
 }
 
 .southamerica:hover {
@@ -191,22 +204,52 @@ footer {
 
 /* mobile styling */
 
-@media (max-width: 1180px) {
-  .flex {
-    margin: 0px;
+@media (max-width: 1440px) {
+  .grid {
+    max-width: 1140px;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-areas:
+    "global asia"
+    "europe namerica"
+    "camerica samerica"
+    "africa oceania"
+    "meast meast";
+  }
+}
+
+@media (max-width: 900px) {
+  .grid {
+    max-width: 720px;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+    "global"
+    "asia"
+    "europe"
+    "namerica"
+    "camerica"
+    "samerica"
+    "africa"
+    "oceania"
+    "meast";
   }
 
   img{
-    width: 400px;
-    height: auto;
+    width: 450px;
+  }
+}
+
+
+@media (max-width: 480px) {
+  img{
+    width: 300px;
+  }
+
+  .box {
+    font-size: 18px;
   }
 
   button{
     font-size: 18px;
     padding: 5px 10px;
-  }
-
-  input[type='button'] {
-    margin: 0px;
   }
 }


### PR DESCRIPTION
This commit removes unnecessary lines of code and converts all of the boxes from a flexbox layout into a grid. It also fixes all of the responsiveness issues and makes the site look slightly neater, especially for the smaller devices. By making the formatting the boxes in a grid, it makes it much easier to position the elements in a more organized and neat manner.